### PR TITLE
ST-11540 Fix added return type to jsonSerialize Fn

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -277,7 +277,7 @@ final class Money implements Arrayable, Jsonable, Stringable, \JsonSerializable
     }
 
     #[\Override]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }


### PR DESCRIPTION
Fixing warning of:
`Return type of Supplycart\Money\Money::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed`